### PR TITLE
Improve Docker image configuration

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.0.0
-version: 0.12.2
+version: 0.13.0
 home: https://github.com/unguiculus/loki-helm-chart
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -28,10 +28,13 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
 | compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
 | compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |
+| compactor.image.registry | string | `nil` | The Docker registry for the compactor image. Overrides `loki.image.registry` |
+| compactor.image.repository | string | `nil` | Docker image repository for the compactor image. Overrides `loki.image.repository` |
+| compactor.image.tag | string | `nil` | Docker image tag for the compactor image. Overrides `loki.image.tag` |
 | compactor.nodeSelector | object | `{}` | Node selector for compactor pods |
 | compactor.persistence.enabled | bool | `false` | Enable creating PVCs for the compactor |
 | compactor.persistence.size | string | `"10Gi"` | Size of persistent disk |
-| compactor.persistence.storageClass | string | `""` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty (the default) or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| compactor.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | compactor.podAnnotations | object | `{}` | Annotations for compactor pods |
 | compactor.resources | object | `{}` | Resource requests and limits for the compactor |
 | compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
@@ -40,13 +43,16 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | distributor.extraArgs | list | `[]` | Additional CLI args for the distributor |
 | distributor.extraEnv | list | `[]` | Environment variables to add to the distributor pods |
 | distributor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the distributor pods |
+| distributor.image.registry | string | `nil` | The Docker registry for the distributor image. Overrides `loki.image.registry` |
+| distributor.image.repository | string | `nil` | Docker image repository for the distributor image. Overrides `loki.image.repository` |
+| distributor.image.tag | string | `nil` | Docker image tag for the distributor image. Overrides `loki.image.tag` |
 | distributor.nodeSelector | object | `{}` | Node selector for distributor pods |
 | distributor.podAnnotations | object | `{}` | Annotations for distributor pods |
 | distributor.replicas | int | `1` | Number of replicas for the distributor |
 | distributor.resources | object | `{}` | Resource requests and limits for the distributor |
 | distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
 | distributor.tolerations | list | `[]` | Tolerations for distributor pods |
-| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
 | gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
 | gateway.basicAuth.enabled | bool | `false` | Enables basic authentication for the gateway |
 | gateway.basicAuth.existingSecret | string | `nil` | Existing basic auth secret to use. Must contain '.htpasswd' |
@@ -56,7 +62,8 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | gateway.extraEnv | list | `[]` | Environment variables to add to the gateway pods |
 | gateway.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the gateway pods |
 | gateway.image.pullPolicy | string | `"IfNotPresent"` | The gateway image pull policy |
-| gateway.image.repository | string | `"docker.io/nginxinc/nginx-unprivileged"` | The gateway image repository |
+| gateway.image.registry | string | `"docker.io"` | The Docker registry for the gateway image |
+| gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
 | gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
 | gateway.ingress.annotations | object | `{}` | Annotations for the gateway ingress |
 | gateway.ingress.enabled | bool | `false` | Specifies whether an ingress for the gateway should be created |
@@ -74,15 +81,19 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | gateway.service.type | string | `"ClusterIP"` | Type of the gateway service |
 | gateway.terminationGracePeriodSeconds | int | `30` | Grace period to allow the gateway to shutdown before it is killed |
 | gateway.tolerations | list | `[]` | Tolerations for gateway pods |
+| global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | ingester.affinity | string | Hard node and soft zone anti-affinity | Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string |
 | ingester.extraArgs | list | `[]` | Additional CLI args for the ingester |
 | ingester.extraEnv | list | `[]` | Environment variables to add to the ingester pods |
 | ingester.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the ingester pods |
+| ingester.image.registry | string | `nil` | The Docker registry for the ingester image. Overrides `loki.image.registry` |
+| ingester.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `loki.image.repository` |
+| ingester.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `loki.image.tag` |
 | ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
 | ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
 | ingester.persistence.size | string | `"10Gi"` | Size of persistent disk |
-| ingester.persistence.storageClass | string | `""` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty (the default) or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| ingester.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
 | ingester.replicas | int | `2` | Number of replicas for the ingester |
 | ingester.resources | object | `{}` | Resource requests and limits for the ingester |
@@ -90,13 +101,15 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | ingester.tolerations | list | `[]` | Tolerations for ingester pods |
 | loki.config | string | See values.yaml | Config file contents for Loki |
 | loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
-| loki.image.repository | string | `"docker.io/grafana/loki"` | Docker image repository |
-| loki.image.tag | string | `""` | Overrides the image tag whose default is the chart's appVersion |
+| loki.image.registry | string | `"docker.io"` | The Docker registry |
+| loki.image.repository | string | `"grafana/loki"` | Docker image repository |
+| loki.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
 | loki.memberlist | bool | `true` | If true, an additional headless service for memberlist (including ingester, distributor, and quierier pods) is created |
 | loki.podAnnotations | object | `{}` | Common annotations for all pods |
 | loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | memcached.image.pullPolicy | string | `"IfNotPresent"` | Memcached Docker image pull policy |
-| memcached.image.repository | string | `"docker.io/memcached"` | Memcached Docker image repository |
+| memcached.image.registry | string | `"docker.io"` | The Docker registry for the memcached |
+| memcached.image.repository | string | `"memcached"` | Memcached Docker image repository |
 | memcached.image.tag | string | `"1.6.7-alpine"` | Memcached Docker image tag |
 | memcachedChunks.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-chunks pods. Passed through `tpl` and, thus, to be configured as string |
 | memcachedChunks.enabled | bool | `false` | Specifies whether the Memcached chunks cache should be enabled |
@@ -111,7 +124,8 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | memcachedChunks.tolerations | list | `[]` | Tolerations for memcached-chunks pods |
 | memcachedExporter.enabled | bool | `false` | Specifies whether the Memcached Exporter should be enabled |
 | memcachedExporter.image.pullPolicy | string | `"IfNotPresent"` | Memcached Exporter Docker image pull policy |
-| memcachedExporter.image.repository | string | `"docker.io/prom/memcached-exporter"` | Memcached Exporter Docker image repository |
+| memcachedExporter.image.registry | string | `"docker.io"` | The Docker registry for the Memcached Exporter |
+| memcachedExporter.image.repository | string | `"prom/memcached-exporter"` | Memcached Exporter Docker image repository |
 | memcachedExporter.image.tag | string | `"v0.6.0"` | Memcached Exporter Docker image tag |
 | memcachedFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-frontend pods. Passed through `tpl` and, thus, to be configured as string |
 | memcachedFrontend.enabled | bool | `false` | Specifies whether the Memcached frontend cache should be enabled |
@@ -146,15 +160,18 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | memcachedIndexWrites.resources | object | `{}` | Resource requests and limits for memcached-index-writes |
 | memcachedIndexWrites.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-index-writes to shutdown before it is killed |
 | memcachedIndexWrites.tolerations | list | `[]` | Tolerations for memcached-index-writes pods |
-| nameOverride | string | `""` | Overrides the chart's name |
+| nameOverride | string | `nil` | Overrides the chart's name |
 | querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
 | querier.extraArgs | list | `[]` | Additional CLI args for the querier |
 | querier.extraEnv | list | `[]` | Environment variables to add to the querier pods |
 | querier.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the querier pods |
+| querier.image.registry | string | `nil` | The Docker registry for the querier image. Overrides `loki.image.registry` |
+| querier.image.repository | string | `nil` | Docker image repository for the querier image. Overrides `loki.image.repository` |
+| querier.image.tag | string | `nil` | Docker image tag for the querier image. Overrides `loki.image.tag` |
 | querier.nodeSelector | object | `{}` | Node selector for querier pods |
 | querier.persistence.enabled | bool | `false` | Enable creating PVCs for the querier cache |
 | querier.persistence.size | string | `"10Gi"` | Size of persistent disk |
-| querier.persistence.storageClass | string | `""` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty (the default) or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| querier.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | querier.podAnnotations | object | `{}` | Annotations for querier pods |
 | querier.replicas | int | `1` | Number of replicas for the querier |
 | querier.resources | object | `{}` | Resource requests and limits for the querier |
@@ -164,6 +181,9 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | queryFrontend.extraArgs | list | `[]` | Additional CLI args for the query-frontend |
 | queryFrontend.extraEnv | list | `[]` | Environment variables to add to the query-frontend pods |
 | queryFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the query-frontend pods |
+| queryFrontend.image.registry | string | `nil` | The Docker registry for the query-frontend image. Overrides `loki.image.registry` |
+| queryFrontend.image.repository | string | `nil` | Docker image repository for the query-frontend image. Overrides `loki.image.repository` |
+| queryFrontend.image.tag | string | `nil` | Docker image tag for the query-frontend image. Overrides `loki.image.tag` |
 | queryFrontend.nodeSelector | object | `{}` | Node selector for query-frontend pods |
 | queryFrontend.podAnnotations | object | `{}` | Annotations for query-frontend pods |
 | queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
@@ -186,6 +206,9 @@ helm repo add loki https://unguiculus.github.io/loki-helm-chart
 | tableManager.extraArgs | list | `[]` | Additional CLI args for the table-manager |
 | tableManager.extraEnv | list | `[]` | Environment variables to add to the table-manager pods |
 | tableManager.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the table-manager pods |
+| tableManager.image.registry | string | `nil` | The Docker registry for the table-manager image. Overrides `loki.image.registry` |
+| tableManager.image.repository | string | `nil` | Docker image repository for the table-manager image. Overrides `loki.image.repository` |
+| tableManager.image.tag | string | `nil` | Docker image tag for the table-manager image. Overrides `loki.image.tag` |
 | tableManager.nodeSelector | object | `{}` | Node selector for table-manager pods |
 | tableManager.podAnnotations | object | `{}` | Annotations for table-manager pods |
 | tableManager.replicas | int | `1` | Number of replicas for the table-manager |

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -62,22 +62,37 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Loki Docker image
+Docker image name for Loki
+*/}}
+{{- define "loki.lokiImage" -}}
+{{- $registry := coalesce .global.registry .service.registry .loki.registry -}}
+{{- $repository := coalesce .service.repository .loki.repository -}}
+{{- $tag := coalesce .service.tag .loki.tag .defaultVersion | toString -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Docker image name
 */}}
 {{- define "loki.image" -}}
-{{ .Values.loki.image.repository }}:{{ .Values.loki.image.tag | default .Chart.AppVersion }}
-{{- end }}
+{{- $registry := coalesce .global.registry .service.registry -}}
+{{- $tag := .service.tag | toString -}}
+{{- printf "%s/%s:%s" $registry .service.repository (.service.tag | toString) -}}
+{{- end -}}
 
 {{/*
 Memcached Docker image
 */}}
 {{- define "loki.memcachedImage" -}}
-{{ .Values.memcached.image.repository }}:{{ .Values.memcached.image.tag }}
+{{- $dict := dict "service" .Values.memcached.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
 {{- end }}
 
 {{/*
 Memcached Exporter Docker image
 */}}
 {{- define "loki.memcachedExporterImage" -}}
-{{ .Values.memcachedExporter.image.repository }}:{{ .Values.memcachedExporter.image.tag }}
+{{- $dict := dict "service" .Values.memcachedExporter.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
 {{- end }}
+

--- a/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
+++ b/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
@@ -20,3 +20,11 @@ compactor selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: compactor
 {{- end }}
+
+{{/*
+compactor image
+*/}}
+{{- define "loki.compactorImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.compactor.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.compactor.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.compactorImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/templates/distributor/_helpers-distributor.tpl
+++ b/charts/loki-distributed/templates/distributor/_helpers-distributor.tpl
@@ -20,3 +20,11 @@ distributor selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: distributor
 {{- end }}
+
+{{/*
+distributor image
+*/}}
+{{- define "loki.distributorImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.distributor.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,7 +42,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.distributor.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.distributorImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/templates/gateway/_helpers-gateway.tpl
+++ b/charts/loki-distributed/templates/gateway/_helpers-gateway.tpl
@@ -27,3 +27,11 @@ Auth secret name
 {{- define "loki.gatewayAuthSecret" -}}
 {{ .Values.gateway.basicAuth.existingSecret | default (include "loki.gatewayFullname" . ) }}
 {{- end }}
+
+{{/*
+Gateway Docker image
+*/}}
+{{- define "loki.gatewayImage" -}}
+{{- $dict := dict "service" .Values.gateway.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
+++ b/charts/loki-distributed/templates/gateway/deployment-gateway.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/gateway/configmap-gateway.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/gateway/configmap-gateway.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
       containers:
         - name: nginx
-          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          image: {{ include "loki.gatewayImage" . }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/loki-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/loki-distributed/templates/ingester/_helpers-ingester.tpl
@@ -20,3 +20,11 @@ ingester selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: ingester
 {{- end }}
+
+{{/*
+ingester image
+*/}}
+{{- define "loki.ingesterImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.ingester.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,7 +42,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.ingesterImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/templates/querier/_helpers-querier.tpl
+++ b/charts/loki-distributed/templates/querier/_helpers-querier.tpl
@@ -20,3 +20,11 @@ querier selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: querier
 {{- end }}
+
+{{/*
+querier image
+*/}}
+{{- define "loki.querierImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.querier.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,7 +42,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.querier.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.querierImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/charts/loki-distributed/templates/query-frontend/_helpers-query-frontend.tpl
@@ -20,3 +20,11 @@ query-frontend selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: query-frontend
 {{- end }}
+
+{{/*
+query-frontend image
+*/}}
+{{- define "loki.queryFrontendImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.queryFrontend.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.queryFrontend.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.queryFrontendImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/templates/table-manager/_helpers-table-manager.tpl
+++ b/charts/loki-distributed/templates/table-manager/_helpers-table-manager.tpl
@@ -20,3 +20,11 @@ table-manager selector labels
 {{ include "loki.selectorLabels" . }}
 app.kubernetes.io/component: table-manager
 {{- end }}
+
+{{/*
+table-manager image
+*/}}
+{{- define "loki.tableManagerImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.tableManager.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- with .Values.loki.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.tableManager.terminationGracePeriodSeconds }}
       containers:
         - name: loki
-          image: {{ include "loki.image" . }}
+          image: {{ include "loki.tableManagerImage" . }}
           imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
           args:
             - -config.file=/etc/loki/loki.yaml

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1,18 +1,25 @@
+global:
+  image:
+    # global.image.registry -- Overrides the Docker registry globally for all images
+    registry: null
+
 # nameOverride -- Overrides the chart's name
-nameOverride: ""
+nameOverride: null
 
 # fullnameOverride -- Overrides the chart's computed fullname
-fullnameOverride: ""
+fullnameOverride: null
 
 # imagePullSecrets -- Image pull secrets for Docker images
 imagePullSecrets: []
 
 loki:
   image:
+    # loki.image.registry -- The Docker registry
+    registry: docker.io
     # loki.image.repository -- Docker image repository
-    repository: docker.io/grafana/loki
+    repository: grafana/loki
     # loki.image.tag -- Overrides the image tag whose default is the chart's appVersion
-    tag: ""
+    tag: null
     # loki.image.pullPolicy -- Docker image pull policy
     pullPolicy: IfNotPresent
   # loki.podAnnotations -- Common annotations for all pods
@@ -129,6 +136,13 @@ serviceMonitor:
 ingester:
   # ingester.replicas -- Number of replicas for the ingester
   replicas: 2
+  image:
+    # ingester.image.registry -- The Docker registry for the ingester image. Overrides `loki.image.registry`
+    registry: null
+    # ingester.image.repository -- Docker image repository for the ingester image. Overrides `loki.image.repository`
+    repository: null
+    # ingester.image.tag -- Docker image tag for the ingester image. Overrides `loki.image.tag`
+    tag: null
   # ingester.podAnnotations -- Annotations for ingester pods
   podAnnotations: {}
   # ingester.extraArgs -- Additional CLI args for the ingester
@@ -171,14 +185,21 @@ ingester:
     # ingester.persistence.storageClass -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
     # If set to "-", storageClassName: "", which disables dynamic provisioning.
-    # If empty (the default) or set to null, no storageClassName spec is
+    # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
-    storageClass: ""
+    storageClass: null
 
 # Configuration for the distributor
 distributor:
   # distributor.replicas -- Number of replicas for the distributor
   replicas: 1
+  image:
+    # distributor.image.registry -- The Docker registry for the distributor image. Overrides `loki.image.registry`
+    registry: null
+    # distributor.image.repository -- Docker image repository for the distributor image. Overrides `loki.image.repository`
+    repository: null
+    # distributor.image.tag -- Docker image tag for the distributor image. Overrides `loki.image.tag`
+    tag: null
   # distributor.podAnnotations -- Annotations for distributor pods
   podAnnotations: {}
   # distributor.extraArgs -- Additional CLI args for the distributor
@@ -216,6 +237,13 @@ distributor:
 querier:
   # querier.replicas -- Number of replicas for the querier
   replicas: 1
+  image:
+    # querier.image.registry -- The Docker registry for the querier image. Overrides `loki.image.registry`
+    registry: null
+    # querier.image.repository -- Docker image repository for the querier image. Overrides `loki.image.repository`
+    repository: null
+    # querier.image.tag -- Docker image tag for the querier image. Overrides `loki.image.tag`
+    tag: null
   # querier.podAnnotations -- Annotations for querier pods
   podAnnotations: {}
   # querier.extraArgs -- Additional CLI args for the querier
@@ -256,14 +284,21 @@ querier:
     # querier.persistence.storageClass -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
     # If set to "-", storageClassName: "", which disables dynamic provisioning.
-    # If empty (the default) or set to null, no storageClassName spec is
+    # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
-    storageClass: ""
+    storageClass: null
 
 # Configuration for the query-frontend
 queryFrontend:
   # queryFrontend.replicas -- Number of replicas for the query-frontend
   replicas: 1
+  image:
+    # queryFrontend.image.registry -- The Docker registry for the query-frontend image. Overrides `loki.image.registry`
+    registry: null
+    # queryFrontend.image.repository -- Docker image repository for the query-frontend image. Overrides `loki.image.repository`
+    repository: null
+    # queryFrontend.image.tag -- Docker image tag for the query-frontend image. Overrides `loki.image.tag`
+    tag: null
   # queryFrontend.podAnnotations -- Annotations for query-frontend pods
   podAnnotations: {}
   # queryFrontend.extraArgs -- Additional CLI args for the query-frontend
@@ -303,6 +338,13 @@ tableManager:
   enabled: false
   # tableManager.replicas -- Number of replicas for the table-manager
   replicas: 1
+  image:
+    # tableManager.image.registry -- The Docker registry for the table-manager image. Overrides `loki.image.registry`
+    registry: null
+    # tableManager.image.repository -- Docker image repository for the table-manager image. Overrides `loki.image.repository`
+    repository: null
+    # tableManager.image.tag -- Docker image tag for the table-manager image. Overrides `loki.image.tag`
+    tag: null
   # tableManager.podAnnotations -- Annotations for table-manager pods
   podAnnotations: {}
   # tableManager.extraArgs -- Additional CLI args for the table-manager
@@ -341,8 +383,10 @@ gateway:
   # gateway.replicas -- Number of replicas for the gateway
   replicas: 1
   image:
+    # gateway.image.registry -- The Docker registry for the gateway image
+    registry: docker.io
     # gateway.image.repository -- The gateway image repository
-    repository: docker.io/nginxinc/nginx-unprivileged
+    repository: nginxinc/nginx-unprivileged
     # gateway.image.tag -- The gateway image tag
     tag: 1.19-alpine
     # gateway.image.pullPolicy -- The gateway image pull policy
@@ -492,6 +536,13 @@ gateway:
 compactor:
   # compactor.enabled -- Specifies whether compactor should be enabled
   enabled: false
+  image:
+    # compactor.image.registry -- The Docker registry for the compactor image. Overrides `loki.image.registry`
+    registry: null
+    # compactor.image.repository -- Docker image repository for the compactor image. Overrides `loki.image.repository`
+    repository: null
+    # compactor.image.tag -- Docker image tag for the compactor image. Overrides `loki.image.tag`
+    tag: null
   # compactor.podAnnotations -- Annotations for compactor pods
   podAnnotations: {}
   # compactor.extraArgs -- Additional CLI args for the compactor
@@ -516,14 +567,16 @@ compactor:
     # compactor.persistence.storageClass -- Storage class to be used.
     # If defined, storageClassName: <storageClass>.
     # If set to "-", storageClassName: "", which disables dynamic provisioning.
-    # If empty (the default) or set to null, no storageClassName spec is
+    # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
-    storageClass: ""
+    storageClass: null
 
 memcached:
   image:
+    # memcached.image.registry -- The Docker registry for the memcached
+    registry: docker.io
     # memcached.image.repository -- Memcached Docker image repository
-    repository: docker.io/memcached
+    repository: memcached
     # memcached.image.tag -- Memcached Docker image tag
     tag: 1.6.7-alpine
     # memcached.image.pullPolicy -- Memcached Docker image pull policy
@@ -533,8 +586,10 @@ memcachedExporter:
   # memcachedExporter.enabled -- Specifies whether the Memcached Exporter should be enabled
   enabled: false
   image:
+    # memcachedExporter.image.registry -- The Docker registry for the Memcached Exporter
+    registry: docker.io
     # memcachedExporter.image.repository -- Memcached Exporter Docker image repository
-    repository: docker.io/prom/memcached-exporter
+    repository: prom/memcached-exporter
     # memcachedExporter.image.tag -- Memcached Exporter Docker image tag
     tag: v0.6.0
     # memcachedExporter.image.pullPolicy -- Memcached Exporter Docker image pull policy


### PR DESCRIPTION
* Allow registry to be configured separately
* Allow registry to be overridden globally for all images
* Allow image overrides per service which can be useful when
  for an updates some components, such as ingesters, should be
  rolled out first

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>