### PR TITLE
These values are required if compactor is enabled

### DIFF
--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -103,6 +103,10 @@ loki:
     frontend:
       log_queries_longer_than: 5s
       compress_responses: true
+      
+    compactor:
+      working_directory: /var/loki/boltdb-shipper-compactor
+      shared_store: filesystem
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
If nothing is set in the config and you've specified `compactor.enabled: true` then the compactor pod fails to start.